### PR TITLE
Proactively check for permissions

### DIFF
--- a/src/utils/bot_activity.ts
+++ b/src/utils/bot_activity.ts
@@ -1,5 +1,6 @@
 import { ActivityType, Client } from "discord.js";
 import { Duration } from "luxon";
+import { error } from "./logger.js";
 
 export function startActivityInterval(client: Client) {
     const statusList = [
@@ -18,8 +19,12 @@ export function startActivityInterval(client: Client) {
     ];
 
     function setRandomStatus() {
-        const randomStatus = statusList[Math.floor(Math.random() * statusList.length)];
-        client.user.setActivity(randomStatus, { type: ActivityType.Custom });
+        try {
+            const randomStatus = statusList[Math.floor(Math.random() * statusList.length)];
+            client.user.setActivity(randomStatus, { type: ActivityType.Custom });
+        } catch (e: any) {
+            error(e);
+        }
     }
 
     setRandomStatus();

--- a/src/utils/hot_drop_queue.ts
+++ b/src/utils/hot_drop_queue.ts
@@ -1,4 +1,4 @@
-import { Client, GuildMember, GuildTextBasedChannel } from "discord.js";
+import { Client, GuildMember, GuildTextBasedChannel, PermissionsBitField } from "discord.js";
 import { DateTime, Duration } from "luxon";
 import { EntityManager } from "typeorm";
 import { config } from "../config.js";
@@ -8,6 +8,7 @@ import Queue from "../tables/Queue.js";
 import QueueStatusMsg from "../tables/QueueStatusMsg.js";
 import { sendErrorToLogChannel } from "./log_channel.js";
 import { verbose } from "./logger.js";
+import { checkDiscordPerms } from "./permissions.js";
 import { logQueueAction } from "./queueLogger.js";
 import { getDeploymentTimeSetting, setDeploymentTimeSetting } from "./settings.js";
 import { startQueuedGameImpl } from "./startQueuedGame.js";
@@ -210,6 +211,13 @@ async function _updateHotDropEmbed(client: Client, nextDeploymentTime: DateTime,
     }
     const queueMessage = queueMessages[0];
     const channel = await client.channels.fetch(queueMessage.channel) as GuildTextBasedChannel;
+    checkDiscordPerms(channel, client.user, new PermissionsBitField(
+        PermissionsBitField.Flags.ViewChannel
+        | PermissionsBitField.Flags.SendMessages
+        | PermissionsBitField.Flags.EmbedLinks
+        | PermissionsBitField.Flags.ReadMessageHistory
+    ));
+
     const message = await channel.messages.fetch(queueMessage.message);
 
     const currentQueue = await Queue.find();

--- a/src/utils/hot_drop_queue.ts
+++ b/src/utils/hot_drop_queue.ts
@@ -65,7 +65,11 @@ export class HotDropQueue {
             await sendErrorToLogChannel(e, this._client);
         }
         this._strikeModeEnabled = false;
-        await this._setNextDeployment(this._deploymentInterval);
+        try {
+            await this._setNextDeployment(this._deploymentInterval);
+        } catch (e: any) {
+            await sendErrorToLogChannel(e, this._client);
+        }
     }
 
     public async clear() {

--- a/src/utils/interaction_format.ts
+++ b/src/utils/interaction_format.ts
@@ -1,4 +1,4 @@
-import { Guild, GuildMember, Interaction, InteractionType, User } from "discord.js";
+import { Channel, Guild, GuildMember, Interaction, InteractionType, User } from "discord.js";
 
 export function formatInteractionDetailsForLog(interaction: Interaction) {
     let member = formatUserForLog(interaction.user);
@@ -43,4 +43,8 @@ export function formatUserForLog(user: User) {
 
 export function formatMemberForLog(member: GuildMember) {
     return `${member.displayName} (${member.nickname}/${member.user.username}/${member.id})`;
+}
+
+export function formatChannelForLog(channel: Channel) {
+    return `${'name' in channel ? channel.name : 'Unknown'} (${channel.id})`;
 }

--- a/src/utils/permissions.ts
+++ b/src/utils/permissions.ts
@@ -1,9 +1,15 @@
 import {
+    CategoryChannel,
     GuildMember,
+    GuildTextBasedChannel,
     PermissionResolvable,
+    PermissionsBitField,
     Role,
-    Snowflake
+    Snowflake,
+    User,
+    VoiceChannel
 } from 'discord.js';
+import { formatChannelForLog, formatUserForLog } from './interaction_format.js';
 
 export interface PermissionsConfig {
     deniedRoles?: Snowflake[];
@@ -43,4 +49,12 @@ function _inDenyList(member: GuildMember, roles: Role[]): Error {
         return new Error(`Denied roles: ${deniedRoles}`);
     }
     return null;
+}
+
+export function checkDiscordPerms(channel: GuildTextBasedChannel | CategoryChannel | VoiceChannel, user: User, requiredPerms: PermissionsBitField): void {
+    const permissions = channel.permissionsFor(user);
+    const missingPermissions = permissions.missing(requiredPerms);
+    if (missingPermissions.length) {
+        throw new Error(`User: ${formatUserForLog(user)} is missing permissions: ${missingPermissions.join(", ")} for channel: ${formatChannelForLog(channel)}`);
+    }
 }

--- a/src/utils/voice_channels.ts
+++ b/src/utils/voice_channels.ts
@@ -40,7 +40,7 @@ export class VoiceChannelManager {
                 },
                 {
                     id: this._client.user.id,
-                    allow: [PermissionsBitField.Flags.ViewChannel, PermissionsBitField.Flags.ManageChannels, PermissionsBitField.Flags.MoveMembers, PermissionsBitField.Flags.CreateInstantInvite]
+                    allow: [PermissionsBitField.Flags.ViewChannel, PermissionsBitField.Flags.ManageChannels, PermissionsBitField.Flags.MoveMembers, PermissionsBitField.Flags.CreateInstantInvite, PermissionsBitField.Flags.Connect, PermissionsBitField.Flags.Speak, PermissionsBitField.Flags.Stream]
                 },
                 {
                     id: hostId,

--- a/src/utils/voice_channels.ts
+++ b/src/utils/voice_channels.ts
@@ -59,17 +59,21 @@ export class VoiceChannelManager {
     }
 
     private async _clearEmptyVoiceChannels() {
-        const clearVcChannelsInterval = Duration.fromDurationLike({ 'minutes': config.discord_server.clear_vc_channels_every_minutes });
-        const deleteChannelAfterVacantFor = clearVcChannelsInterval.minus({ 'seconds': 30 });
-        debug("Clearing empty voice channels");
-        const guild = this._client.guilds.cache.get(config.guildId);
-        for (const prefix of [config.discord_server.strike_vc_category_prefix, config.discord_server.hotdrop_vc_category_prefix]) {
-            for (const vcCategory of _findAllVcCategories(guild, prefix).values()) {
-                for (const channel of vcCategory.children.cache.values()) {
-                    await this._removeOldVoiceChannel(this._client, channel, deleteChannelAfterVacantFor);
+        try {
+            const clearVcChannelsInterval = Duration.fromDurationLike({ 'minutes': config.discord_server.clear_vc_channels_every_minutes });
+            const deleteChannelAfterVacantFor = clearVcChannelsInterval.minus({ 'seconds': 30 });
+            debug("Clearing empty voice channels");
+            const guild = this._client.guilds.cache.get(config.guildId);
+            for (const prefix of [config.discord_server.strike_vc_category_prefix, config.discord_server.hotdrop_vc_category_prefix]) {
+                for (const vcCategory of _findAllVcCategories(guild, prefix).values()) {
+                    for (const channel of vcCategory.children.cache.values()) {
+                        await this._removeOldVoiceChannel(this._client, channel, deleteChannelAfterVacantFor);
 
+                    }
                 }
             }
+        } catch (e: any) {
+            sendErrorToLogChannel(e, this._client);
         }
     }
 


### PR DESCRIPTION
The discord permissions error does not specify what permissions are missing. We proactively check for permissions and provide a meaningful and helpful message if permissiosn are missing before attempting an operation.

This does not protect us from permissions we need but not yet know about but we can add them when we figure out what perms we need.