### PR TITLE
Move secrets to dynamically loaded json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,4 @@ node_modules
 package-lock.json
 package.json
 dist/
-src/config/secrets.ts
-*.json
+secrets.json

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,4 @@
-import secrets from "./config/secrets.js";
+import { secrets } from "./config/secrets_loader.js";
 import { config_dev } from "./config_dev.js";
 import { config_prod } from "./config_prod.js";
 

--- a/src/config/secrets.sample.json
+++ b/src/config/secrets.sample.json
@@ -1,0 +1,8 @@
+{
+    "discord_app_token": "token",
+    "db_host": "something.host.com",
+    "db_username": "username",
+    "db_password": "password",
+    "db_name": "db_name",
+    "env": "dev"
+}

--- a/src/config/secrets.ts
+++ b/src/config/secrets.ts
@@ -1,9 +1,0 @@
-export default {
-    // Bot token - you can access it from the Discord Developer Portal: https://discord.com/developers/applications
-    discord_app_token: null,
-    db_host: null,
-    db_username: null,
-    db_password: null,
-    db_name: null,
-    env: "dev",
-}

--- a/src/config/secrets_loader.ts
+++ b/src/config/secrets_loader.ts
@@ -1,0 +1,33 @@
+/*
+The secrets file and this loader exist because our hosting does not support env
+variables or any other way to provide this dynamically.
+*/
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+import { fatal } from '../utils/logger.js';
+
+interface Secrets {
+    // Bot token - you can access it from the Discord Developer Portal: https://discord.com/developers/applications
+    discord_app_token: string,
+    db_host: string,
+    db_username: string,
+    db_password: string,
+    db_name: string,
+    env: 'dev' | 'prod',
+};
+
+const currentFilePath = fileURLToPath(import.meta.url);
+const currentDirectory = path.dirname(currentFilePath);
+const rootDir = path.normalize(path.join(currentDirectory, '..', '..'));
+const secretsFilePath = path.join(rootDir, 'secrets.json');
+
+let fileData: string = null;
+try {
+    fileData = fs.readFileSync(secretsFilePath, 'utf-8');
+} catch (e: any) {
+    fatal(`Failed to load secrets file. Please make sure you set up your secrets file at: ${secretsFilePath}. Error: ${e}`);
+}
+
+export const secrets = JSON.parse(fileData) as Secrets;

--- a/src/config_dev.ts
+++ b/src/config_dev.ts
@@ -1,6 +1,6 @@
 import { ButtonStyle } from "discord.js";
 import { discord_server_config_dev } from "./config/discord_server_dev.js";
-import secrets from "./config/secrets.js";
+import { secrets } from "./config/secrets_loader.js";
 
 export const config_dev = {
     token: secrets.discord_app_token,

--- a/src/config_prod.ts
+++ b/src/config_prod.ts
@@ -1,6 +1,6 @@
 import { ButtonStyle } from "discord.js";
 import { discord_server_config_prod } from "./config/discord_server_prod.js";
-import secrets from "./config/secrets.js";
+import { secrets } from "./config/secrets_loader.js";
 
 export const config_prod = {
     token: secrets.discord_app_token,


### PR DESCRIPTION
This way we don't need to overwrite a repo file which is very annoying in the dev environment with rebasing and switching branches.

Since the secrets file is no longer part of the repository, it will survive fetching an updated version of the repo in our production env.